### PR TITLE
fix: ANLSPI-20697 compatible for general implementations that avoid doesNotRecognizeSelector crash

### DIFF
--- a/GrowingUtils.podspec
+++ b/GrowingUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GrowingUtils'
-  s.version          = '1.2.3'
+  s.version          = '1.2.4'
   s.summary          = 'iOS SDK of GrowingIO.'
   s.description      = <<-DESC
 GrowingAnalytics具备自动采集基本的用户行为事件，比如访问和行为数据等。目前支持代码埋点、无埋点、可视化圈选、热图等功能。

--- a/Sources/TrackerCore/Swizzle/GrowingULSwizzler.m
+++ b/Sources/TrackerCore/Swizzle/GrowingULSwizzler.m
@@ -354,27 +354,8 @@ static NSMutableSet *swizzledClassesForKey(const void *key){
 }
 
 + (id)realDelegate:(id)proxy toSelector:(SEL)selector {
-    if (!proxy) {
-        return nil;
-    }
-
-    id realDelegate = proxy;
-    id obj = nil;
-    do {
-        //避免proxy本身实现了该方法或通过resolveInstanceMethod添加了方法实现
-        if (class_getInstanceMethod(object_getClass(realDelegate), selector)) {
-            break;
-        }
-
-        //如果使用了NSProxy或者快速转发,判断forwardingTargetForSelector是否实现
-        //默认forwardingTargetForSelector都有实现，只是返回为nil
-        obj = ((id(*)(id, SEL, SEL))objc_msgSend)(realDelegate, @selector(forwardingTargetForSelector:), selector);
-        if (!obj)
-            break;
-        realDelegate = obj;
-    } while (obj);
-
-    return realDelegate;
+    // 不再兼容forwardingTargetForSelector场景，仅通过下方的class_respondsToSelector判断当前类是否有对应实现
+    return proxy;
 }
 
 + (BOOL)realDelegateClass:(Class)cls respondsToSelector:(SEL)sel {


### PR DESCRIPTION
## PR 内容

此 PR 删除了 `forwardingTargetForSelector` 消息转发场景的 hook 兼容，实际上这种场景非常少。

以下是背景描述：
对于 `doesNotRecognizeSelector` 崩溃，通常的防护手段是：
开发者通过在 `forwardingTargetForSelector` 判断是否有 selector 的实现，如果没有，则创建一个新的桩对象并添加对应 selector 实现，将消息转发到该桩对象，之后再通过日志上报等手段汇报崩溃场景。具体的可以看[大白防护系统](https://mp.weixin.qq.com/s?__biz=MzUxMzcxMzE5Ng==&mid=2247488311&idx=1&sn=0db090c8d4a5efafa47f00af4b3f174f&source=41#wechat_redirect)中相关介绍，

> 以上防护手段的前提是，`forwardingTargetForSelector` 仅在业务代码在运行时经过从消息查找到消息转发的整个流程，当前对象未实现对应方法，即将发生消息转发或者崩溃。

在 https://github.com/growingio/growingio-sdk-ios-autotracker/pull/87 的改动中，直接通过 `objc_msgSend` 调用 `forwardingTargetForSelector`，与上述防护手段不兼容。可能会导致桩对象无故生成，甚至是崩溃。

`_UIEditMenuListView` 就是一个例子，该内部类声明了协议 `UICollectionViewDelegate`，但未实现 `collectionView:didSelectItemAtIndexPath:` 方法，在 GrowingIO SDK 和 `doesNotRecognizeSelector` 防护手段的共同作用下，出现桩对象无故生成，甚至是崩溃。

## 测试步骤

* 测试 `UICollectionView/UITableView` 正常点击采集
* 测试 `_UIEditMenuListView` setDelegate hook 不会造成崩溃 （在唤起键盘后，长按 UITextField 控件文字输入区域）
* 测试集成了 `doesNotRecognizeSelector` 防护手段的代码后，`_UIEditMenuListView` setDelegate hook 不会造成崩溃

## 影响范围

* `UICollectionView/UITableView` 点击采集

## 是否属于重要变动？

- [x] 是
- [ ] 否

