### PR TITLE
fix: ANLSPI-26449 move to Xcode 16

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -5,15 +5,9 @@ on:
 
 jobs:
   publish:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
-      - name: Update Cocoapods Version
-        run: sudo gem install cocoapods
-
-      - name: Force Xcode 15
-        run: sudo xcode-select -switch /Applications/Xcode_15.2.app
-
       - name: Checkout Repo
         uses: actions/checkout@v4
         

--- a/.github/workflows/pod_lint.yml
+++ b/.github/workflows/pod_lint.yml
@@ -12,15 +12,9 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
-      - name: Update Cocoapods Version
-        run: sudo gem install cocoapods
-        
-      - name: Force Xcode 15
-        run: sudo xcode-select -switch /Applications/Xcode_15.2.app
-        
       - name: Checkout Repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -12,28 +12,22 @@ concurrency:
 
 jobs:
   build-iOS:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
-      - name: Force Xcode 15
-        run: sudo xcode-select -switch /Applications/Xcode_15.2.app
-
       - name: Checkout Repo
         uses: actions/checkout@v4
 
       - name: Build
         run: |
           set -euo pipefail
-          xcodebuild build -scheme GrowingUtils-Package -destination 'platform=iOS Simulator,name=iPhone 15 Pro Max' \
+          xcodebuild build -scheme GrowingUtils-Package -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max' \
           | xcbeautify --renderer github-actions
 
   build-catalyst:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
-      - name: Force Xcode 15
-        run: sudo xcode-select -switch /Applications/Xcode_15.2.app
-
       - name: Checkout Repo
         uses: actions/checkout@v4
 
@@ -44,12 +38,9 @@ jobs:
           | xcbeautify --renderer github-actions
 
   build-macOS:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
-      - name: Force Xcode 15
-        run: sudo xcode-select -switch /Applications/Xcode_15.2.app
-
       - name: Checkout Repo
         uses: actions/checkout@v4
 
@@ -60,12 +51,9 @@ jobs:
           | xcbeautify --renderer github-actions
 
   build-watchOS:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
-      - name: Force Xcode 15
-        run: sudo xcode-select -switch /Applications/Xcode_15.2.app
-
       - name: Checkout Repo
         uses: actions/checkout@v4
 
@@ -76,12 +64,9 @@ jobs:
           | xcbeautify --renderer github-actions
 
   build-tvOS:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
-      - name: Force Xcode 15
-        run: sudo xcode-select -switch /Applications/Xcode_15.2.app
-
       - name: Checkout Repo
         uses: actions/checkout@v4
 
@@ -92,12 +77,9 @@ jobs:
           | xcbeautify --renderer github-actions
 
   build-visionOS:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
-      - name: Force Xcode 15
-        run: sudo xcode-select -switch /Applications/Xcode_15.2.app
-
       - name: Checkout Repo
         uses: actions/checkout@v4
 


### PR DESCRIPTION
https://developer.apple.com/news/?id=9s0rgdy9

Beginning April 24, 2025, apps uploaded to App Store Connect must be built with Xcode 16 or later using an SDK for iOS 18, iPadOS 18, tvOS 18, visionOS 2, or watchOS 11.